### PR TITLE
Fix cgroup paths to work with lxd 3.9

### DIFF
--- a/usr/local/sbin/lxd-telegraf-stats.py
+++ b/usr/local/sbin/lxd-telegraf-stats.py
@@ -12,7 +12,7 @@ import re
 
 # pylxd dont have storage functions yet
 # so define storage pool name here
-lxdstorage = "zfs"
+lxdstorage = "default"
 outputtype = "influx"
 
 SYMBOLS = {
@@ -194,26 +194,26 @@ for container in client.containers.all():
       lxdmetrics[cn]['net'][interface]['bytes_in'] = cno.network[interface]['counters']['bytes_received']
   except:
     pass
-  
+
   # cgroup metrics - read them only when container is running
   if lxdmetrics[cn]['running'] == 1:
-    if os.path.exists('/sys/fs/cgroup/cpu,cpuacct/lxc/%s/cpu.shares' % cn):
+    if os.path.exists('/sys/fs/cgroup/cpu,cpuacct/lxc.monitor/%s/cpu.shares' % cn):
       try:
-        with open('/sys/fs/cgroup/cpu,cpuacct/lxc/%s/cpu.shares' % cn, 'rt') as cgfile:
+        with open('/sys/fs/cgroup/cpu,cpuacct/lxc.monitor/%s/cpu.shares' % cn, 'rt') as cgfile:
           lxdmetrics[cn]['cpuprio'] = int(cgfile.read())
       except:
         pass
   
-    if os.path.exists('/sys/fs/cgroup/blkio/lxc/%s/blkio.weight' % cn):
+    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.weight' % cn):
       try:
-        with open('/sys/fs/cgroup/blkio/lxc/%s/blkio.weight' % cn, 'rt') as cgfile:
+        with open('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.weight' % cn, 'rt') as cgfile:
           lxdmetrics[cn]['hddprio'] = int(cgfile.read())
       except:
         pass
 
-    if os.path.exists('/sys/fs/cgroup/blkio/lxc/%s/blkio.throttle.io_serviced' % cn):
+    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.throttle.io_serviced' % cn):
       try:
-        with open('/sys/fs/cgroup/blkio/lxc/%s/blkio.throttle.io_serviced' % cn, 'rt') as cgfile:
+        with open('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.throttle.io_serviced' % cn, 'rt') as cgfile:
           for line in cgfile.readlines():
             # sum every read or write occuring
             if "Read" in line:


### PR DESCRIPTION
Fix cgroup paths to work with lxd 3.9 and change lxdstorage to default