### PR TITLE
fix monitor/payload locations for lxd > 4.x

### DIFF
--- a/usr/local/sbin/lxd-telegraf-stats.py
+++ b/usr/local/sbin/lxd-telegraf-stats.py
@@ -197,24 +197,23 @@ for container in client.containers.all():
 
   # cgroup metrics - read them only when container is running
   if lxdmetrics[cn]['running'] == 1:
-    lxdmetrics[cn]['cpuprio'] = 0
-    if os.path.exists('/sys/fs/cgroup/cpu,cpuacct/lxc.monitor/%s/cpu.shares' % cn):
+    if os.path.exists('/sys/fs/cgroup/cpu,cpuacct/lxc.monitor.%s/cpu.shares' % cn):
       try:
-        with open('/sys/fs/cgroup/cpu,cpuacct/lxc.monitor/%s/cpu.shares' % cn, 'rt') as cgfile:
+        with open('/sys/fs/cgroup/cpu,cpuacct/lxc.monitor.%s/cpu.shares' % cn, 'rt') as cgfile:
           lxdmetrics[cn]['cpuprio'] = int(cgfile.read())
       except:
         pass
-    lxdmetrics[cn]['hddprio'] = 0
-    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.weight' % cn):
+  
+    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload.%s/blkio.weight' % cn):
       try:
-        with open('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.weight' % cn, 'rt') as cgfile:
+        with open('/sys/fs/cgroup/blkio/lxc.payload.%s/blkio.weight' % cn, 'rt') as cgfile:
           lxdmetrics[cn]['hddprio'] = int(cgfile.read())
       except:
         pass
 
-    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.throttle.io_serviced' % cn):
+    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload.%s/blkio.throttle.io_serviced' % cn):
       try:
-        with open('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.throttle.io_serviced' % cn, 'rt') as cgfile:
+        with open('/sys/fs/cgroup/blkio/lxc.payload.%s/blkio.throttle.io_serviced' % cn, 'rt') as cgfile:
           for line in cgfile.readlines():
             # sum every read or write occuring
             if "Read" in line:
@@ -241,9 +240,9 @@ for container in client.containers.all():
       except:
         pass
   
-    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.throttle.io_service_bytes' % cn):
+    if os.path.exists('/sys/fs/cgroup/blkio/lxc.payload.%s/blkio.throttle.io_service_bytes' % cn):
       try:
-        with open('/sys/fs/cgroup/blkio/lxc.payload/%s/blkio.throttle.io_service_bytes' % cn, 'rt') as cgfile:
+        with open('/sys/fs/cgroup/blkio/lxc.payload.%s/blkio.throttle.io_service_bytes' % cn, 'rt') as cgfile:
           for line in cgfile.readlines():
             if "Read" in line:
               #device = ask_sysfs(line.split()[0])


### PR DESCRIPTION
Hi Jan,

i updated the paths for the new lxd versions wich got moved from

> /sys/fs/cgroup/blkio/lxc.payload/%s/
to
> /sys/fs/cgroup/blkio/lxc.payload.%s/

Test
`lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=status running=1,processes=28,cpuprio=1024,hddprio=500
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=mem usage=536363008,usage_pct=24,limit=2147483648,peak=536453120
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=swap usage=0,peak=0
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=cpu usage=9387216276,limit=2,usage_percpu=4693608138
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=blkio bytes_total=668315648,iops_total=11018,bytes_write=61693952,iops_write=2612,bytes_read=606621696,iops_read=8406
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=net,dev=erspan0 pkts_out=0,bytes_in=0,bytes_out=0,pkts_in=0
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=net,dev=gretap0 pkts_out=0,bytes_in=0,bytes_out=0,pkts_in=0
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=net,dev=eth0 pkts_out=27424,bytes_in=14997392,bytes_out=10784040,pkts_in=30777
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=net,dev=gre0 pkts_out=0,bytes_in=0,bytes_out=0,pkts_in=0
lxd,type=container,hostname=influxdb-2,name=influxdb,instance=2,metric=net,dev=lo pkts_out=4843,bytes_in=9217954,bytes_out=9217954,pkts_in=4843
lxd,type=master,metric=mem total=33586675712,given=70093897728,used=7763312640,given_pct=208,used_pct=23
lxd,type=master,metric=other live=1
lxd,type=master,metric=hdd total=1,given=0,used=10,given_pct=0,used_pct=1000
lxd,type=master,metric=cpu given=33,total=8
lxd,type=master,metric=containers running=10,total=10,notrunning=0
`